### PR TITLE
Fixes incorrect type narrowing of nullable string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ declare module "types-joi" {
 
         valid<U>(...values: readonly U[]): Schema<U>;
 
-        required(): Schema<NonNullable<T>>;
+        required(): Schema<T extends undefined ? never : T>;
         optional(): Schema<T | undefined>;
 
         forbidden(): Schema<never>;

--- a/test.ts
+++ b/test.ts
@@ -19,7 +19,8 @@ const schema = joi
             .array()
             .required()
             .items(joi.string().required()),
-        buf: joi.binary().required()
+        buf: joi.binary().required(),
+        allowNullButRequired: joi.string().allow(null).required(),
     })
     .required();
 


### PR DESCRIPTION
When creating a Joi schema with modifiers `.allow(null).required()`, the type of the resulting object is not correctly nullable even if it passes the runtime check

```ts
const schema = joi.object({
   x: joi.string().allow(null).required()
})

const result = joi.attempt({ x: null }, schema)
// expected: typeof result = { x: string | null } 
```

Current Behavior
![current (incorrect) behavior](https://user-images.githubusercontent.com/6354012/150235847-7c11ab10-c6ae-4650-b13d-02343c62f745.png)

Expected Behavior
![expected](https://user-images.githubusercontent.com/6354012/150235850-83df3d19-3e4b-47ac-b1a9-598181fc1a05.png)
